### PR TITLE
Remove broken link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,6 @@ In addition of this list, you should read the list [awesome-shell](https://githu
 -   [Advanced Bash-Scripting Guide](http://tldp.org/LDP/abs/html/) - An in-depth exploration of the art of shell scripting
 -   [Bash Guide for Beginners](http://www.tldp.org/LDP/Bash-Beginners-Guide/html/) (by Machtelt Garrels)
 -   [Bash Programming - Intro/How-to](http://tldp.org/HOWTO/Bash-Prog-Intro-HOWTO.html#toc)
--   [The Command Line Crash Course](http://learncodethehardway.org/cli/book/) - A crash course for some common unix and shell commands
 -   [bash-handbook](https://github.com/denysdovhan/bash-handbook) - A handbook for those who want to learn Bash without diving in too deeply
 -   [Google's Shell Style Guide](https://google.github.io/styleguide/shell.xml)  - Reasonable advice about code style
 -   [Sobell's Book](http://www.sobell.com/CR3/index.html) - A practical guide to commands, editors, and shell programming

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ In addition of this list, you should read the list [awesome-shell](https://githu
 -   [Advanced Bash-Scripting Guide](http://tldp.org/LDP/abs/html/) - An in-depth exploration of the art of shell scripting
 -   [Bash Guide for Beginners](http://www.tldp.org/LDP/Bash-Beginners-Guide/html/) (by Machtelt Garrels)
 -   [Bash Programming - Intro/How-to](http://tldp.org/HOWTO/Bash-Prog-Intro-HOWTO.html#toc)
+-   [The Command Line Crash Course](https://learnpythonthehardway.org/book/appendixa.html) - A crash course for some common unix and shell commands
 -   [bash-handbook](https://github.com/denysdovhan/bash-handbook) - A handbook for those who want to learn Bash without diving in too deeply
 -   [Google's Shell Style Guide](https://google.github.io/styleguide/shell.xml)  - Reasonable advice about code style
 -   [Sobell's Book](http://www.sobell.com/CR3/index.html) - A practical guide to commands, editors, and shell programming


### PR DESCRIPTION
The website appears to have a new link up here https://learncodethehardway.org/unix/
But it just prompts user to buy something.

Looking at archive it seems to have been an online free book before: https://web.archive.org/web/20151020105515/http://learncodethehardway.org/cli/book