### PR TITLE
Add xiringuito - SSH-based "VPN for poors"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ In addition of this list, you should read the list [awesome-shell](https://githu
 -   [bashttpd](https://github.com/avleen/bashttpd) - A web server written in Bash
 -   [Dropbox-Uploader](https://github.com/andreafabrizi/Dropbox-Uploader) - Dropbox Uploader is a Bash script which can be used to upload, download, list or delete files from Dropbox
 -   [ngincat](https://github.com/jaburns/ngincat) - Tiny Bash HTTP server using netcat
+-   [xiringuito](https://github.com/ivanilves/xiringuito) - SSH-based VPN for poors
 
 ## Applications
 


### PR DESCRIPTION
Add xiringuito - SSH-based "VPN for poors"

# WHY?
`xiringuito` is awesome, because:
* easy to install (no dependencies, no configurations)
* allows you to manage one, few or many connections easily (and connect em simultaneously if you want)
* it has `xaval` connection manager - a tool that may record and later re-use your connection profiles
* though you are free to use or not to use `xaval` connection manager - people also use `xiringuito` for ad-hoc onetime connections
* Just look at this GIF :wink: 
![](https://github.com/ivanilves/xiringuito/raw/master/images/install.gif)