### PR TITLE
Add zoxide

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,7 @@ In addition of this list, you should read the list [awesome-shell](https://githu
 - [hstr](https://github.com/dvorka/hstr) - Bash History Suggest Box
 - [qfc](https://github.com/pindexis/qfc) - File-completion widget for Bash and Zsh
 - [sshrc](https://github.com/Russell91/sshrc) - Bring your .bashrc, .vimrc, etc. with you when you SSH
+- [zoxide](https://github.com/ajeetdsouza/zoxide) - A better way to navigate your filesystem. Written in Rust, cross-shell, and much faster than other autojumpers.
 
 ## Customization
 


### PR DESCRIPTION
zoxide is a blazing fast autojump alternative written in Rust. It's orders of magnitude faster than other autojumpers, cross-shell, and extremely feature-rich.