### PR TITLE
Update README and add todo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,7 @@ In addition of this list, you should read the list [awesome-shell](https://githu
 - [bashblog](https://github.com/cfenollosa/bashblog) - A Bash script that handles blog posting
 - [pushbullet-bash](https://github.com/Red5d/pushbullet-bash) - Bash interface to the PushBullet API
 - [todo.sh](https://github.com/todotxt/todo.txt-cli) - A simple and extensible shell script for managing your todo.txt file
+- [todo](https://github.com/dzove855/todo) - A simple and minimal devtodo v1 replacement in bash
 - [cheapci](https://github.com/ianmiell/cheapci) - A continuous integration framework implemented in bash
 
 ## Games


### PR DESCRIPTION
todo is a simple devtodo v1 replacement in bash. It's directory base, which allows setting priorities and mark object as ongoing and update entrys.