### PR TITLE
add bashhub-server

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ In addition of this list, you should read the list [awesome-shell](https://githu
 
 - [aliases](https://github.com/sebglazebrook/aliases) - Contextual, dynamic, organized aliases for the bash shell
 - [bashhub](https://github.com/rcaloras/bashhub-client) - :cloud: Bash history in the cloud. Indexed and searchable.
+- [bashhub-server](https://github.com/nicksherron/bashhub-server) - Privately hosted open source bashhub server.
 - [bashmarks](https://github.com/huyng/bashmarks) - Directory bookmarks for the shell
 - [commacd](https://github.com/shyiko/commacd) - A faster way to move around in Bash
 - [has](https://github.com/kdabir/has) - `has` helps you check presence of various command line tools and their versions on path


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/awesome-lists/awesome-bash/blob/master/contributing.md).

**Repo or homepage link:**
https://github.com/nicksherron/bashhub-server

**Description:**

bashhub-server compliments the already listed bashhub project by adding a highly requested feature of privately hosting the server component. 

**Why I think it's awesome:**

Well I think bashhub is awesome and apparently, you all do too, and I think [Ryan](https://github.com/rcaloras) did a great job on the project. That being said, I think we should be able to use the client without having to send our shell history to a closed source backend that we don't have any control over. This project gives people the option to send their history to their own server while still getting all the perks of the bashhub client;  along with a few extras (like regex). There's also an [issue](https://github.com/rcaloras/bashhub-client/issues/47) in the client repo where others share similar opinions.