### PR TITLE
Add Bashmatic

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,7 @@ In addition of this list, you should read the list [awesome-shell](https://githu
 -   [bashing](https://github.com/xsc/bashing) - Smashing Bash into Pieces - Bash framework for creating command line tools
 -   [bashly](https://github.com/DannyBen/bashly) - Bash command line framework and CLI generator
 -   [bashmanager](https://github.com/lingtalfi/bashmanager) - mini bash framework for creating command line tools
+-   [Bashmatic](https://github.com/kigster/bashmatic) - easy to use DSL  framework for building BASH-based tooling & installers.
 -   [BashScriptTestingLibrary](https://github.com/rafritts/BashScriptTestingLibrary) - A unit testing framework for Bash scripts
 -   [Bash Infinity](https://github.com/niieani/bash-oo-framework) - A modern boilerplate / framework / standard library for bash
 -   [bash-modules](https://github.com/vlisivka/bash-modules) - a collection of modules for [unofficial strict mode](http://redsymbol.net/articles/unofficial-bash-strict-mode/)

--- a/readme.md
+++ b/readme.md
@@ -129,7 +129,7 @@ In addition of this list, you should read the list [awesome-shell](https://githu
 -   [bashing](https://github.com/xsc/bashing) - Smashing Bash into Pieces - Bash framework for creating command line tools
 -   [bashly](https://github.com/DannyBen/bashly) - Bash command line framework and CLI generator
 -   [bashmanager](https://github.com/lingtalfi/bashmanager) - mini bash framework for creating command line tools
--   [Bashmatic](https://github.com/kigster/bashmatic) - easy to use DSL  framework for building BASH-based tooling & installers.
+-   [Bashmatic](https://github.com/kigster/bashmatic) - an easy to use DSL library for building BASH-based tooling & installers (900+ functions).
 -   [BashScriptTestingLibrary](https://github.com/rafritts/BashScriptTestingLibrary) - A unit testing framework for Bash scripts
 -   [Bash Infinity](https://github.com/niieani/bash-oo-framework) - A modern boilerplate / framework / standard library for bash
 -   [bash-modules](https://github.com/vlisivka/bash-modules) - a collection of modules for [unofficial strict mode](http://redsymbol.net/articles/unofficial-bash-strict-mode/)


### PR DESCRIPTION
#### New App Submission

- [X] I've read the [contribution guidelines](https://github.com/awesome-lists/awesome-bash/blob/master/contributing.md).

**Repo or homepage link:**

[https://github.com/kigster/bashmatic](https://github.com/kigster/bashmatic)

**Description:**

Bashmatic is a rich BASH library consisting of nearly 900 BASH functions, and yet it takes about 80ms to load all 900 of them. The library includes helpers covering a wide range of functionality, such as array functions, database, color, UI elements (try `h1 "hello"`), and many many more. 

Bashmatic comes with easy-to-read [PDF documentation](https://github.com/kigster/bashmatic/blob/main/README.pdf). Please take a quick look.

Bashmatic's programming style is heavily influenced by the DSL languages that are similar to those of popular Ruby projects. 

**Why I think it's awesome:**

When writing BASH-based installers or a glue script, one of the most frustrating experiences is not knowing what is running, where it broke, and so on. Bashmatic prints every command it runs, including the time it took and the exit code. This is called the "runtime" sub-system of Bashmastic.

Take a look at a couple of examples:

1. [A simple example that installs `minicube` and `k8s`](https://github.com/kigster/bashmatic#example-ii-download-and-install-binaries)
2. [A much more complete example is this one: `${BASHMATIC_HOME}/bin/dev-setup`](https://github.com/kigster/bashmatic#63-example-iii-developer-environment-bootstrap-script)

At least several dozen of dev-environment setup projects use Bashmatic with huge success.
