### PR TITLE
Pretty sure the bash community migrated from Freenode over to Libra.Chat.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ In addition of this list, you should read the list [awesome-shell](https://githu
 - [Stack Overflow](http://stackoverflow.com/questions/tagged/bash) - Bash tag on Stack Overflow
 - [/r/Bash](https://www.reddit.com/r/bash) - A subreddit dedicated to bash scripting
 - [/r/CommandLine](https://www.reddit.com/r/commandline) - for anything regarding the command line, in any operating system
-- [#bash](https://webchat.freenode.net/?channels=bash) - IRC channel on freenode. The main contributors of the BashGuide, BashFAQ, BashPitfalls and ShellCheck hang around there
+- [#bash](https://web.libera.chat/?nick=Guest?#bash) - IRC channel on Libera.​Chat. The main contributors of the BashGuide, BashFAQ, BashPitfalls and ShellCheck hang around there
 
 ## Other Awesome Lists
 


### PR DESCRIPTION
<!---
Thank you for your pull request.
Please fill out the fields below and check that
your contribution adheres to our guidelines.
-->

**Description:**

Pretty sure the bulk of the #bash irc discussion is now happening on Libra.Chat after the freenode issues last year.
