### PR TITLE
Replace dead links to bash-hackers.org with links to Wayback Machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ In addition of this list, you should read the list [awesome-shell](https://githu
 
 ## Books and Resources
 
-- [The Bash-Hackers Wiki](http://wiki.bash-hackers.org/doku.php) - Human-readable documentation of any kind about GNU Bash
-- [Bash beginner's mistakes](http://wiki.bash-hackers.org/scripting/newbie_traps) (by the Bash-Hackers Wiki)
+- [The Bash-Hackers Wiki](https://web.archive.org/web/20230406205817/https://wiki.bash-hackers.org/) - Human-readable documentation of any kind about GNU Bash
+- [Bash beginner's mistakes](https://web.archive.org/web/20230330234404/https://wiki.bash-hackers.org/scripting/newbie_traps) (by the Bash-Hackers Wiki)
 - [Bash Guide](http://mywiki.wooledge.org/BashGuide) - A bash guide for beginners. (by Lhunath)
 - [Bash FAQ](http://mywiki.wooledge.org/BashFAQ) - Answers most of your questions (by Lhunath)
 - [Bash Pitfalls](http://mywiki.wooledge.org/BashPitfalls) - Lists the common pitfalls beginners fall into, and how to avoid them


### PR DESCRIPTION
The wiki at bash-hackers.org is no more, but most of the content is archived by the Wayback Machine.