### PR TITLE
Add Bash web projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ In addition to this list, you should read the list [awesome-shell](https://githu
 - [balls](https://github.com/jneen/balls) - Bash on Balls.
 - [bashttpd](https://github.com/avleen/bashttpd) - A web server written in Bash.
 - [sherver](https://github.com/remileduc/sherver) - Pure Bash lightweight web server.
+- [httpd.sh](https://github.com/cemeyer/httpd.sh) - A trivial web server in bash, using ctypes.sh.
+- [Bash-web-server](https://github.com/dzove855/Bash-web-server) - A purely bash web server, no socat, netcat, etc.
+- [bash-stack](https://github.com/cgsdev0/bash-stack) - modern web framework in bash.
 - [Dropbox-Uploader](https://github.com/andreafabrizi/Dropbox-Uploader) - Dropbox Uploader is a Bash script which can be used to upload, download, list or delete files from Dropbox.
 - [ngincat](https://github.com/jaburns/ngincat) - Tiny Bash HTTP server using netcat.
 - [xiringuito](https://github.com/ivanilves/xiringuito) - SSH-based VPN for poors.


### PR DESCRIPTION
<!---
Thank you for your pull request.
Please fill out the fields below and check that
your contribution adheres to our guidelines.
-->

#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/awesome-lists/awesome-bash/blob/master/contributing.md).

**Repo or homepage link:**

https://github.com/cemeyer/httpd.sh
https://github.com/dzove855/Bash-web-server
https://github.com/cgsdev0/bash-stack
 
**Description:**

It is an http server written in Bash. It's design is significantly different than others on this list, because it leverages [ctypes.sh](https://github.com/taviso/ctypes.sh/), a Bash library which allows for interfacing with a FFI

**Why I think it's awesome:**

It uses a popular Bash repository for serving a website, which is still very awesome, for a bash project. The other two projects are similar, except they have more recent commit dates. `Bash-web-server` uses built-ins, rather than some FFI interface. And, `bash-stack` is a framework rather than an example project like the others.

Closes #116

