### PR TITLE
suggestion: Add oosh to the list of Bash tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ In addition to this list, you should read the list [awesome-shell](https://githu
 - [bocker](https://github.com/p8952/bocker) - Docker implemented in 100 lines of bash.
 - [git-sh](https://github.com/rtomayko/git-sh) - A customized Bash environment suitable for Git work.
 - [mkdkr](https://github.com/rosineygp/mkdkr) - Make + Docker + Shell = CI Pipeline.
+- [oosh](https://github.com/bruno-de-queiroz/oosh) - Zero-dependency bash framework that turns annotated shell functions into full CLI tools with auto-generated help, flag parsing, and tab completion.
 
 ## Downloading and Serving
 


### PR DESCRIPTION
#### New App Submission

- [-] I've read the [contribution guidelines](https://github.com/awesome-lists/awesome-bash/blob/master/contributing.md).

**Repo or homepage link:**
https://github.com/bruno-de-queiroz/oosh
Original gist from 9 years ago: https://gist.github.com/bruno-de-queiroz/a1c9e5b24b6118e45f4eb2402e69b2a4

**Description:**
oosh is an annotation-driven bash CLI framework with a built-in code generator. You write plain bash functions, sprinkle a few annotations like #@public, #@flag, and #@description, and oosh gives you a fully-featured command-line tool — complete with auto-generated help text, flag parsing with environment variable exports, and tab completion — all with zero external dependencies. The generator scaffolds an entire CLI project in seconds, including install/uninstall commands, modular architecture (just drop .sh files into modules/). It's designed to be lightweight, agent-friendly, and get out of your way so you can focus on writing the logic that matters.

**Why I think it's awesome:**
Because it does exactly what you'd spend hours wiring up by hand — help output, flag parsing, autocompletion, modular command routing — and gives it to you for free with a couple of comment annotations. There's no runtime to install, no build step, no config files, no YAML, no dependency tree. It's just bash calling bash. An AI agent can scaffold a production-ready CLI tool by writing a single .sh file, and a human can understand every line of it. In a world obsessed with overengineered toolchains, oosh is a reminder that sometimes the best tool is the one that was already on your machine.