### PR TITLE
feat: add releaserun CLI to For Developers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ In addition to this list, you should read the list [awesome-shell](https://githu
 - [bocker](https://github.com/p8952/bocker) - Docker implemented in 100 lines of bash.
 - [git-sh](https://github.com/rtomayko/git-sh) - A customized Bash environment suitable for Git work.
 - [mkdkr](https://github.com/rosineygp/mkdkr) - Make + Docker + Shell = CI Pipeline.
+- [releaserun](https://github.com/Releaserun/releaserun-cli) - Scan project dependencies for end-of-life status, known CVEs, and outdated packages across Node.js, Python, Go, Rust, and Dockerfiles.
 
 ## Downloading and Serving
 


### PR DESCRIPTION
## Summary

Adding [releaserun](https://github.com/Releaserun/releaserun-cli) to the **For Developers** section.

`releaserun` is an open-source CLI tool that scans project dependencies for end-of-life versions, known CVEs, and outdated packages. It supports Node.js (`package.json`), Python (`requirements.txt`), Go (`go.mod`), Rust (`Cargo.toml`), and Dockerfiles.

```bash
npm install -g releaserun
releaserun check  # scan current project
```

Available on npm and as a GitHub Action for CI/CD integration.

**Checklist:**
- [x] Entry is alphabetically ordered within the section
- [x] Entry follows the existing format: `[name](url) - Description.`
- [x] Links to GitHub repo (not a website)