### PR TITLE
Removes "Data" from "Contents" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ In addition to this list, you should read the list [awesome-shell](https://githu
 - [Books and Resources](#books-and-resources)
 - [Command-Line Productivity](#command-line-productivity)
 - [Customization](#customization)
-- [Data](#data)
 - [For Developers](#for-developers)
 - [Downloading and Serving](#downloading-and-serving)
 - [Applications](#applications)


### PR DESCRIPTION
<!---
Thank you for your pull request.
Please fill out the fields below and check that
your contribution adheres to our guidelines.
-->

- [x] I've read the [contribution guidelines](https://github.com/awesome-lists/awesome-bash/blob/master/contributing.md).

In #146, the Data category was removed. However, it still exists in the Contents and points to a non-existent section.
