### PR TITLE
Add in-cli to Command-Line Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ In addition to this list, you should read the list [awesome-shell](https://githu
 - [forkrun](https://github.com/jkool702/forkrun) - A pure-bash tool for running code in parallel. Similar in syntax and speed to `xargs -P`, but with more features and native Bash function support.
 - [has](https://github.com/kdabir/has) - `has` helps you check presence of various command line tools and their versions on path.
 - [hstr](https://github.com/dvorka/hstr) - Bash History Suggest Box.
+- [in-cli](https://github.com/inevolin/in-cli) - Execute shell commands across multiple directories sequentially or in parallel.
 - [sshrc](https://github.com/cdown/sshrc) - Bring your .bashrc, .vimrc, etc. with you when you SSH.
 - [utility-bash-scripts](https://github.com/aviaryan/utility-bash-scripts) - Useful bash scripts to do automatable tasks with a single command.
 - [zoxide](https://github.com/ajeetdsouza/zoxide) - A better way to navigate your filesystem. Written in Rust, cross-shell, and much faster than other autojumpers.


### PR DESCRIPTION
## Summary
- add in-cli to the Command-Line Productivity section
- describe it as a Bash tool for running commands across multiple directories sequentially or in parallel

## Why
in-cli is a pure Bash utility for batch command execution across multiple directories, so it fits this list's Bash-focused productivity tooling.