### PR TITLE
Add say-it — pronunciation CLI for developer jargon

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ In addition to this list, you should read the list [awesome-shell](https://githu
 - [bocker](https://github.com/p8952/bocker) - Docker implemented in 100 lines of bash.
 - [git-sh](https://github.com/rtomayko/git-sh) - A customized Bash environment suitable for Git work.
 - [mkdkr](https://github.com/rosineygp/mkdkr) - Make + Docker + Shell = CI Pipeline.
+- [say-it](https://github.com/anzy-renlab-ai/pronounce) - Bash CLI that pronounces 540+ developer jargon names (kubectl, GIF, JWT, …) out loud with cited sources, audible alternates, and a Claude Code skill. Zero dependencies, wraps macOS `say`.
 
 ## Downloading and Serving
 


### PR DESCRIPTION
**Repo:** https://github.com/anzy-renlab-ai/pronounce · **Live:** https://pronounce.renlab.ai

Tiny pure-Bash CLI (no deps, wraps macOS `say`) that pronounces developer project / product / jargon names out loud — `kubectl` → "koob control", `GIF` → "jif" (Wilhite, Webby Awards 2013), `JSON` → "jay-son" (Crockford, RailsConf 2009), `JWT` → "jot" (RFC 7519), 540+ entries total, every entry with a cited source.

```
$ say-it kubectl
🔊  koob control. koob control. koob control. or: cube cuddle. or: kube C T L.
```

Inserted alphabetically under \`## For Developers\`. MIT licensed.